### PR TITLE
Fix: Add staff member validation to report command

### DIFF
--- a/src/main/java/me/PirotKiller/staffLink/commands/StaffCommand.java
+++ b/src/main/java/me/PirotKiller/staffLink/commands/StaffCommand.java
@@ -35,21 +35,25 @@ public class StaffCommand implements TabExecutor {
             }
 
             String staffMemberName = args[0];
-            StringBuilder reasonBuilder = new StringBuilder();
-            for (int i = 1; i < args.length; i++) {
-                reasonBuilder.append(args[i]).append(" ");
-            }
-            String reason = reasonBuilder.toString().trim();
+            if (main.getStaffMembers().contains(staffMemberName)) {
+                StringBuilder reasonBuilder = new StringBuilder();
+                for (int i = 1; i < args.length; i++) {
+                    reasonBuilder.append(args[i]).append(" ");
+                }
+                String reason = reasonBuilder.toString().trim();
 
-            if (main.getStaffReportWebhookUrl() == null || main.getStaffReportWebhookUrl().isEmpty()) {
-                new UChat().sendMessage(reporter,"§cError: Discord Webhook URL is not configured. Report cannot be sent.");
-                main.getLogger().severe("Attempted to send staff report, but webhook URL is missing!");
+                if (main.getStaffReportWebhookUrl() == null || main.getStaffReportWebhookUrl().isEmpty()) {
+                    new UChat().sendMessage(reporter, "§cError: Discord Webhook URL is not configured. Report cannot be sent.");
+                    main.getLogger().severe("Attempted to send staff report, but webhook URL is missing!");
+                    return true;
+                }
+
+                functions.sendToDiscord(reporter.getName(), staffMemberName, reason);
+                new UChat().sendMessage(reporter, "§aYour report against §e" + staffMemberName + "§a has been submitted.");
                 return true;
-            }
-
-            functions.sendToDiscord(reporter.getName(), staffMemberName, reason);
-            new UChat().sendMessage(reporter,"§aYour report against §e" + staffMemberName + "§a has been submitted.");
-            return true;
+            }else{
+            new UChat().sendMessage(reporter,"§cInvalid Staff member does not exist.");
+        }
         }
         return false;
     }


### PR DESCRIPTION
## Changes:
- Added validation to check if the reported staff member exists in the staff list
- Improved error handling for invalid staff member names
- Restructured command logic for better readability

## Testing:
- [✔] Verified that reports work for valid staff members
- [✔] Confirmed proper error message is shown for invalid staff members
- [✔] Tested with empty/non-existent staff list

## Notes:
- This change prevents reports from being sent for non-existent staff members
- Error messages have been made more user-friendly

Closes issue:  #1 